### PR TITLE
Allow defining a port to the redfish API

### DIFF
--- a/check_redfish.py
+++ b/check_redfish.py
@@ -53,6 +53,7 @@ class RedfishConnection():
     vendor_dict_key = None
     vendor_data = None
     cli_args = None
+    port = None
 
     def __init__(self, cli_args = None):
 
@@ -63,6 +64,9 @@ class RedfishConnection():
             raise Exception("cli args host not set")
 
         self.cli_args = cli_args
+
+        if cli_args.port:
+            cli_args.port = ":%s" % cli_args.port
 
         self.sessionfilepath = self.get_session_file_name()
         self.restore_session_from_file()
@@ -269,7 +273,7 @@ class RedfishConnection():
 
         # initialize connection
         try:
-            self.connection = redfish.redfish_client(base_url="https://%s" % self.cli_args.host, max_retry=self.cli_args.retries, timeout=self.cli_args.timeout)
+            self.connection = redfish.redfish_client(base_url="https://%s%s" % (self.cli_args.host, self.cli_args.port), max_retry=self.cli_args.retries, timeout=self.cli_args.timeout)
         except redfish.rest.v1.ServerDownOrUnreachableError:
             self.exit_on_error("Host '%s' down or unreachable." % self.cli_args.host, "CRITICAL")
         except redfish.rest.v1.RetriesExhaustedError:
@@ -652,6 +656,8 @@ def parse_command_line():
     group = parser.add_argument_group(title="optional arguments")
     group.add_argument("-h", "--help", action='store_true',
                         help="show this help message and exit")
+    group.add_argument("-P", "--port",
+                        help="define the port of the redfish API" )
     group.add_argument("-w", "--warning", default="",
                         help="set warning value")
     group.add_argument("-c", "--critical", default="",


### PR DESCRIPTION
Hello and thanks for a nice check!

Maybe redfish is always on port 443, but when testing this I just wanted to
be minimally invasive so just setup an SSH tunnel from my laptop.

- CentOS 7.7
- Python 3.6

```
$ ssh bastion.example.org -L 4444:myserversipmi.example.org:443
```
<pre>
$ rm -v /tmp/check_redfish*
$ for test in $(echo "storage proc memory power temp fan nic bmc info firmware sel mel"); do python3 check_redfish.py -H localhost -u USER -p PASS -P 4444 --$test; done[UNKNOWN]: No storage controller and disk drive data found in system
[OK]: All processors (2) are in good condition
[OK]: All memory modules (Total 64GB) are in good condition
[OK]: All power supplies (2) are in good condition and power redundancy status is: Disabled[OK]: All temp sensors (6) are in good condition|'Temp_CPU1_Temp'=33;;90 'Temp_CPU2_Temp'=32;;90 'Temp_System_Board_Inlet_Temp'=22;38;42 'Temp_System_Board_GPU1_Temp'=35 'Temp_System_Board_GPU8_Temp'=32 'Temp_System_Board_Exhaust_Temp'=27;75;80
[OK]: All fans (6) are in good condition and fan redundancy status is: Enabled|'Fan_System_Board_Fan1'=7200;; 'Fan_System_Board_Fan2'=7080;; 'Fan_System_Board_Fan3'=7080;; 'Fan_System_Board_Fan4'=6960;; 'Fan_System_Board_Fan5'=7200;; 'Fan_System_Board_Fan6'=7200;;[OK]: All network interfaces (6) are in good condition
[OK]: iDRAC 14G Monolithic (3.32.32.32) and nics are in 'OK' state.
[OK]: Type: Dell Inc. PowerEdge R740 (CPU: 2, MEM: 64GB) - BIOS: 2.1.8 - Serial: ASERIAL - Power: On - Name: PowerEdgeR740-ASERIAL
[OK]: Found 22 firmware entries. Use '--detailed' option to display them.
Traceback (most recent call last):
  File "check_redfish.py", line 2918, in <module>
    if "sel"        in args.requested_query: get_event_log("System")
  File "check_redfish.py", line 1794, in get_event_log
    get_event_log_dell_fujitsu(type, system_manager_id)
  File "check_redfish.py", line 1988, in get_event_log_dell_fujitsu
    if event_entry.get("EntryCode")[0].get("Member") == "Deassert" and assoc_id is not None:
AttributeError: 'str' object has no attribute 'get'
[OK]: Found 50 OK Manager Event Log entries. Most recent notable: [OK]: 2020-02-05T23:18:17-06:00: Successfully logged in using root, from SECRETIP and REDFISH.
</pre>
I can run it again afterwards without any username or password or port, so the new port setting seems to be saved in the session too which is cool because I didn't read that part of the code :)

On a related note about the session, I don't know much more about redfish other than it's available on some devices' OOB interface that I manage. I guess the access in the sessionfile is to a redfish session which I hope expires at some point?