### PR TITLE
Add inventory option to plugin

### DIFF
--- a/check_redfish.py
+++ b/check_redfish.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3.6
 
 self_description = \
-"""This is a monitoring plugin to check components and
+"""This is a monitoring/inventory plugin to check components and
 health status of systems which support Redfish.
+It will also create a inventory of all components of a system.
 
 R.I.P. IPMI
 """
@@ -1152,7 +1153,8 @@ def parse_command_line():
     group.add_argument("-c", "--critical", default="",
                         help="set critical value")
     group.add_argument("-v", "--verbose",  action='store_true',
-                        help="this will add all requests and responses to output")
+                        help="this will add all https requests and responses to output, "
+                        "also adds inventory source data to all inventory objects")
     group.add_argument("-d", "--detailed",  action='store_true',
                         help="always print detailed result")
     group.add_argument("-m", "--max",  type=int,
@@ -1161,8 +1163,6 @@ def parse_command_line():
                         help="set number of maximum retries (default: %d)" % default_conn_max_retries)
     group.add_argument("-t", "--timeout",  type=int, default=default_conn_timeout,
                         help="set number of request timeout per try/retry (default: %d)" % default_conn_timeout)
-    group.add_argument("-i", "--inventory",  action='store_true',
-                        help="return inventory in json format instead of regular plugin output")
 
     # require at least one argument
     group = parser.add_argument_group(title="query status/health information (at least one is required)")
@@ -1192,6 +1192,11 @@ def parse_command_line():
                         help="request Management Processor Log status")
     group.add_argument("--all", dest="requested_query", action='append_const', const="all",
                         help="request all of the above information at once.")
+
+    # inventory
+    group = parser.add_argument_group(title="query inventory information (no health check)")
+    group.add_argument("-i", "--inventory",  action='store_true',
+                        help="return inventory in json format instead of regular plugin output")
 
     result = parser.parse_args()
 

--- a/check_redfish.py
+++ b/check_redfish.py
@@ -889,6 +889,7 @@ class Inventory(object):
 
         # add metadata
         inventory_content["meta"] = {
+            "WARNING": "THIS is a alpha version of this implementation and possible changes might occur without notice",
             "start_of_data_collection": self.inventory_start.replace(tzinfo=datetime.timezone.utc).astimezone().replace(microsecond=0).isoformat(),
             "duration_of_data_colection_in_seconds": (datetime.datetime.utcnow() - self.inventory_start).total_seconds(),
             "inventory_layout_version": inventory_layout_version_string,


### PR DESCRIPTION
This PR will add an "--inventory" option to be able to retrieve all system components in json formatted dictionary

The basic structure looks like this:
```
{
    "inventory": {
        "chassis": [],
        "fans": [],
        "firmware": [],
        "logical_drives": [],
        "managers": [],
        "memories": [],
        "meta": {
            "WARNING": "THIS is a alpha version of this implementation and possible changes might occur without notice",
            "data_retrieval_issues": [],
            "duration_of_data_colection_in_seconds": 0.018014,
            "host_that_collected_inventory": "hostname",
            "inventory_layout_version": "0.1",
            "script_version": "0.0.11",
            "start_of_data_collection": "2020-02-26T07:59:39+01:00"
        },
        "nics": [],
        "physical_drives": [],
        "power_supplies": [],
        "processors": [],
        "storage_controllers": [],
        "storage_enclosures": [],
        "systems": [],
        "temperatures": []
    }
}
```

**THIS is the first alpha version of this implementation and possible changes might occur without notice**

Fixes: #6