### PR TITLE
Fixing missing Manager field info on iLO 5 >2.3.0

### DIFF
--- a/cr_module/classes/redfish.py
+++ b/cr_module/classes/redfish.py
@@ -451,8 +451,20 @@ class RedfishConnection:
                 if manager_data is not None:
                     self.vendor_data.ilo_hostname = manager_data.get("HostName")
                     self.vendor_data.ilo_version = manager_data.get("ManagerType")
+                    if self.vendor_data.ilo_version is None:
+                        # Fix for iLO 5 version >2.3.0
+                        moniker_data = grab(self.connection.root, f"Oem.{vendor_string}.Moniker")
+                        self.vendor_data.ilo_version = moniker_data.get("PRODGEN")
+                  
                     self.vendor_data.ilo_firmware_version = manager_data.get("ManagerFirmwareVersion")
-
+                    if self.vendor_data.ilo_firmware_version is None:
+                        # Fix for iLO 5 version >2.3.0
+                        self.vendor_data.ilo_firmware_version = manager_data.get("Languages").pop().get("Version")
+                    
+                    if None in [self.vendor_data.ilo_hostname, self.vendor_data.ilo_version,
+                                self.vendor_data.ilo_firmware_version]:
+                            self.exit_on_error("Cannot determine HPE iLO version information.")
+                    
                     if self.vendor_data.ilo_version.lower() == "ilo 5":
                         self.vendor_data.view_supported = True
 


### PR DESCRIPTION
The fields Manager.ManagerType / Manager.ManagerFirmwareVersion 
do not exist on iLO 5 from version 2.3.0 to the current 2.3.1 (and probably
further versions as well):

Fields on Version 2.18:
```
iLOrest > get --selector=ServiceRoot
Oem=
     Hpe=
          Moniker=
                   SUMGR=Smart Update Manager
                   PRODGEN=iLO 5
                   ADVLIC=iLO Advanced
                   FEDGRP=DEFAULT
          Manager=
                   ManagerFirmwareVersion=2.18
                   Status=
                           Health=OK
                   ManagerType=iLO 5
                   HostName=ILODD4444444
                   FQDN=ILODD4444444.
                   DefaultLanguage=en
                   Languages=
                              Version=2.18
                              Language=en
```

Fields on Version >2.30:
```
iLOrest > get --selector=ServiceRoot
Oem=
     Hpe=
          Moniker=
                   VNIC=Virtual NIC
                   SUMGR=Smart Update Manager
                   PRODGEN=iLO 5
...
          Manager=
                   Languages=
                              Version=2.30
                              Language=en
                              TranslationName=English
                   HostName=ILODD4444444
                   FQDN=None
                   DefaultLanguage=en
```

Checking an iLO with version >2.3.0 therefore results in the following error:

```
Traceback (most recent call last):
  File "/usr/lib64/nagios/plugins/check_redfish-1.1.0/check_redfish.py", line 198, in <module>
    plugin.rf.determine_vendor()
  File "/usr/lib64/nagios/plugins/check_redfish-1.1.0/cr_module/classes/redfish.py", line 456, in determine_vendor
    if self.vendor_data.ilo_version.lower() == "ilo 5":
AttributeError: 'NoneType' object has no attribute 'lower'
```
