### PR TITLE
Set date/time to epoch when exception occurs

### DIFF
--- a/cr_module/event.py
+++ b/cr_module/event.py
@@ -74,7 +74,8 @@ def get_log_entry_time(entry_date=None):
             entry_date_object = datetime.datetime.strptime(entry_date, string_format)
             entry_date_object = entry_date_object.replace(tzinfo=local_timezone)
         except Exception:
-            pass
+            entry_date_object = datetime.datetime.strptime('1970-01-01T00:00:00Z', string_format)
+            entry_date_object = entry_date_object.replace(tzinfo=local_timezone)
 
     return entry_date_object
 


### PR DESCRIPTION
This handles the case when date/time is '000-00-00T00:00:00Z' on a log 
entry.  Seen from HP DL360 Gen10.

fixes #49 