### PR TITLE
added more supported systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ Almost all Server which have iLO4 (>=2.50) or iLO5 (>=1.20) should work
 
 ### Lenovo
 * ThinkSystem SR650 (BMC Version 2.12)
+* ThinkAgile HX7520 Appliance (Lenovo XClarity Controller v5.4)
+* ThinkAgile HX3720 Appliance (Lenovo XClarity Controller v4.2)
 
 ### Dell
 * PowerEdge R630   (iDRAC 8 Version 2.70.70.70)
@@ -361,6 +363,7 @@ Almost all Server which have iLO4 (>=2.50) or iLO5 (>=1.20) should work
 * PowerEdge R7515  (iDRAC 9 Version 4.10.10.10)
 * PowerEdge R840   (iDRAC 9 Version 4.22.00.00)
 * PowerEdge R930   (iDRAC 8 Version 2.70.70.70)
+* XC6420 Appliance (Firmware: 5.00.20.00 & BIOS 2.12.2)
 
 ### Huawei
 * TaiShan 2280 V2 (iBMC Version 3.63)


### PR DESCRIPTION
worth mentioning, what the "hardware colleagues" told me:
The HX3720 system is a 4-node appliance in a 2 hu chassis sharing two powersupplies over all 4 nodes.
The powersupply check is not completely able to gather the data though.
```
[UNKNOWN]: Request error: No power supply data returned for API URL '/redfish/v1/Chassis/1/Power', No power supply data returned for API URL '/redfish/v1/Chassis/2/Power'|'power_control_Server_Power_Control'=263.0 'power_control_CPU_Sub-system_Power'=155.0 'power_control_Memory_Sub-system_Power'=49.0

```

The 4-node/2hu stuff with the powersupplies goes for the Dell XC6420 as well, but here the data can be fetched from the API.