### PR TITLE
Adds a check for ILO5 SecurityState

### DIFF
--- a/check_redfish.py
+++ b/check_redfish.py
@@ -31,6 +31,7 @@ from cr_module.system_chassi import get_system_info, get_chassi_data, get_system
 from cr_module.nic import get_network_interfaces
 from cr_module.storage import get_storage
 from cr_module.bmc import get_bmc_info
+from cr_module.securityservice import get_securityservice_info
 from cr_module.firmware import get_firmware_info
 from cr_module.event import get_event_log
 from cr_module.classes.redfish import default_conn_max_retries, default_conn_timeout
@@ -113,6 +114,8 @@ def parse_command_line():
                        help="request System Log status")
     group.add_argument("--mel", dest="requested_query", action='append_const', const="mel",
                        help="request Management Processor Log status")
+    group.add_argument("--security", dest="requested_query", action='append_const', const="security",
+                       help="request Security Service")
     group.add_argument("--all", dest="requested_query", action='append_const', const="all",
                        help="request all of the above information at once")
 
@@ -174,6 +177,7 @@ if __name__ == "__main__":
     if any(x in args.requested_query for x in ['firmware', 'all']): get_firmware_info(plugin)
     if any(x in args.requested_query for x in ['mel', 'all']):      get_event_log(plugin, "Manager")
     if any(x in args.requested_query for x in ['sel', 'all']):      get_event_log(plugin, "System")
+    if any(x in args.requested_query for x in ['security', 'all']): get_securityservice_info(plugin)
 
     plugin.do_exit()
 

--- a/cr_module/securityservice.py
+++ b/cr_module/securityservice.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#  Copyright (c) 2020 - 2022 Ricardo Bartels. All rights reserved.
+#
+#  check_redfish.py
+#
+#  This work is licensed under the terms of the MIT license.
+#  For a copy, see file LICENSE.txt included in this
+#  repository or visit: <https://opensource.org/licenses/MIT>.
+
+from cr_module.classes.inventory import Manager, NetworkPort
+from cr_module.common import get_status_data, grab
+from cr_module.firmware import get_firmware_info_fujitsu
+from cr_module.nic import get_interface_ip_addresses, format_interface_addresses
+import pprint
+
+
+def get_securityservice_info(plugin_object):
+
+    plugin_object.set_current_command("Security Service")
+
+    managers = plugin_object.rf.get_system_properties("managers")
+
+    if managers is None or len(managers) == 0:
+        plugin_object.inventory.add_issue(Manager, "No 'managers' property found in root path '/redfish/v1'")
+        return
+
+    for manager in managers:
+        if plugin_object.rf.vendor == "HPE":
+            get_security_info_hp(plugin_object, manager)
+
+    return
+
+
+def get_security_info_hp(plugin_object, redfish_url):
+    """
+    Checks if SecurityState is Production, HighSecurity, ...
+    """
+
+    view_response = plugin_object.rf.get_view(f"{redfish_url}{plugin_object.rf.vendor_data.expand_string}")
+
+    if view_response.get("error"):
+        plugin_object.add_data_retrieval_error(Manager, view_response, redfish_url)
+        return
+
+    # HPE iLO 5 view
+    if view_response.get("ILO"):
+        manager_response = view_response.get("ILO")[0]
+    else:
+        return
+    manager_id = manager_response.get("Id")
+    vendor_data = grab(manager_response, f"Oem.{plugin_object.rf.vendor_dict_key}")
+    security_service_link = grab(vendor_data, "Links/SecurityService/@odata.id", separator="/")
+    security_service_response = plugin_object.rf.get(security_service_link)
+    security_state = security_service_response.get("SecurityState")
+
+    status_text = f"SecurityState is {security_state}"
+    plugin_object.add_output_data("WARNING" if security_state in ["Production", "Wipe"] else "OK", status_text,
+                                  summary=True, location=f"Manager {manager_id}")
+
+    return
+


### PR DESCRIPTION
Hi,

my admins pointed me to a setting SecurityState which can be used to enforce ssl and some stronger security guidelines.
https://support.hpe.com/hpesc/public/docDisplay?docId=a00030074en_us&docLocale=en_US
It can be queried by 
```
curl -u ilomonuser:secret  --insecure -L https://my-gen10-hp/redfish/v1/managers/1/securityservice | jq
{
  "@odata.context": "/redfish/v1/$metadata#HpeSecurityService.HpeSecurityService",
  "@odata.etag": "W/\"0D950D81\"",
  "@odata.id": "/redfish/v1/Managers/1/SecurityService",
  "@odata.type": "#HpeSecurityService.v2_3_1.HpeSecurityService",
  "Id": "SecurityService",
  "CurrentCipher": "ECDHE-RSA-AES256-GCM-SHA384",
  "Links": {
...
  "SecurityState": "Production",
  "SecurityState@Redfish.AllowableValues": [
    "Production",
    "HighSecurity",
    "FIPS"
  ],
...
```

It warns if the value of this setting is default/weak.
```
check_redfish.py --security ...
[WARNING]: SecurityState is Production
```

I tried to understand your way to implement all the functions (thanks a lot for all these features by the way) and added my code in cr_module/securityservice.py
Not sure if it looks like if you implemented it yourself. Feel free to modify it like you want in case you accept the pull request.

Gerhard


