### PR TITLE
Add support processor type GPU

### DIFF
--- a/cr_module/classes/inventory.py
+++ b/cr_module/classes/inventory.py
@@ -290,7 +290,8 @@ class Processor(InventoryItem):
        "serial",
        "socket",
        "system_ids",
-       "threads"
+       "threads",
+       "type"
     ]
 
 


### PR DESCRIPTION
This PR aims to add support for GPU processors during the inventory export.
Unfortunately the "source_data" related to the retrieved GPU is a bit sparse in content compared to that of the CPUs, which is why there are few fields valued.
I'm attaching an example of source_data where I proceeded to make a small redaction on the serial and part number. The rest is intact:

```json
"source_data":{
   "@odata.context":"/redfish/v1/$metadata#Processor.Processor",
   "@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/Video.Slot.34-1",
   "@odata.type":"#Processor.v1_12_0.Processor",
   "Assembly":{
      "@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Assembly"
   },
   "Description":"Represents the properties of the GPU attached to this System",
   "Id":"Video.Slot.34-1",
   "Links":{
      "Chassis":{
         "@odata.id":"/redfish/v1/Chassis/System.Embedded.1"
      },
      "Oem":{
         "Dell":{
            "@odata.type":"#DellOem.v1_3_0.DellOemLinks",
            "CPUAffinity":[
               {
                  "@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1"
               }
            ],
            "CPUAffinity@odata.count":1
         }
      },
      "PCIeDevice":{
         "@odata.id":"/redfish/v1/Systems/System.Embedded.1/PCIeDevices/23-0"
      },
      "PCIeFunctions":[
         {
            "@odata.id":"/redfish/v1/Systems/System.Embedded.1/PCIeDevices/23-0/PCIeFunctions/23-0-0"
         }
      ]
   },
   "Manufacturer":"NVIDIA Corporation",
   "Metrics":{
      "@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/Video.Slot.34-1/ProcessorMetrics"
   },
   "Model":"NVIDIA A30",
   "Name":"Video.Slot.34-1",
   "Oem":{
      "Dell":{
         "@odata.type":"#DellOem.v1_3_0.DellOemResources",
         "DellAccelerators":null,
         "DellProcessor":null,
         "PowerMetrics":{
            "@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/Video.Slot.34-1/Oem/Dell/PowerMetrics"
         },
         "ThermalMetrics":{
            "@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/Video.Slot.34-1/Oem/Dell/ThermalMetrics"
         }
      }
   },
   "PartNumber":"XXX-YYYYY-AAAAA-XXXX",
   "ProcessorType":"GPU",
   "SerialNumber":"XZXZXZXZXZXZXZXZXZX",
   "Status":{
      "Health":"OK",
      "State":"Enabled"
   }
}

```
Thanks

Tested on Dell PowerEdge R750xa