### PR TITLE
Get hostname in a cross-platform way

### DIFF
--- a/cr_module/classes/inventory.py
+++ b/cr_module/classes/inventory.py
@@ -14,6 +14,7 @@ import sys
 
 from cr_module.classes import plugin_status_types
 from cr_module.common import grab
+from socket import gethostname
 
 # inventory definition
 inventory_layout_version_string = "1.4.0"
@@ -619,7 +620,7 @@ class Inventory(object):
             "duration_of_data_collection_in_seconds": (datetime.datetime.utcnow()-self.inventory_start).total_seconds(),
             "inventory_layout_version": inventory_layout_version_string,
             "data_retrieval_issues": self.data_retrieval_issues,
-            "host_that_collected_inventory": os.uname()[1],
+            "host_that_collected_inventory": gethostname(),
             "script_version": self.plugin_version,
             "inventory_id": self.inventory_id,
             "inventory_name": self.inventory_name,


### PR DESCRIPTION
os.uname()[1] only works on Unix-like operating systems (and also truncates the hostname to 8 characters on some systems), socket.gethostname() gets the same data in a better cross-platform way.

In my case this was the only thing I needed to change to get this running on Windows (to collect inventory data)

Reference: https://docs.python.org/3/library/os.html#os.uname