### PR TITLE
Added option --sessionlock which prevents multiple sessions and locks the session file when connecting

### DIFF
--- a/check_redfish.py
+++ b/check_redfish.py
@@ -57,6 +57,7 @@ def parse_command_line():
     group.add_argument("-f", "--authfile", help="authentication file with user name and password")
     group.add_argument("--sessionfile", help="define name of session file")
     group.add_argument("--sessionfiledir", help="define directory where the plugin saves session files")
+    group.add_argument("--sessionlock", action='store_true', help="prevents multiple sessions and locks the session file when connecting")
     group.add_argument("--nosession", action='store_true',
                        help="Don't establish a persistent session and log out after check is finished")
 


### PR DESCRIPTION
**Overview**
This update addresses an issue encountered when running the check_redfish.py script in parallel with different modes (e.g., storage, processor, memory). During initialization, multiple instances of the script may attempt to establish connections simultaneously, leading to an excessive number of open sessions. This happens because the session file is only written after a successful connection (which takes a while) and other instances can overwrite it. This result in reaching the session limit of an Integrated Lights-Out (iLO) interface or similar management interfaces.

**Problem**
When the session limit is reached, no more logins into the management interface are possible. Also every subsequent check attempt creates additional session requests, potentially leading to more failures and unexpected behavior.

**Solution**
To mitigate this issue,  i added a lock file mechanism. This lock file ensures that multiple instances of the script do not open new sessions concurrently if a session is already in the process of being established. By coordinating access to session creation, this approach prevents exceeding the session limit and maintains system stability. I made this parameter optional so if not needed or wanted no lock file will be used.