### PR TITLE
fix critical and warning limits not working on log entries for HPE

### DIFF
--- a/cr_module/event.py
+++ b/cr_module/event.py
@@ -197,12 +197,10 @@ def get_event_log_hpe(event_type, redfish_path):
             forced_limit = True
             limit_of_returned_items = ilo4_limit
 
-    if event_type == "Manager":
-
-        if plugin_object.cli_args.warning:
-            date_warning = data_now - datetime.timedelta(days=int(plugin_object.cli_args.warning))
-        if plugin_object.cli_args.critical:
-            date_critical = data_now - datetime.timedelta(days=int(plugin_object.cli_args.critical))
+    if plugin_object.cli_args.warning:
+        date_warning = data_now - datetime.timedelta(days=int(plugin_object.cli_args.warning))
+    if plugin_object.cli_args.critical:
+        date_critical = data_now - datetime.timedelta(days=int(plugin_object.cli_args.critical))
 
     event_entries = plugin_object.rf.get(redfish_path).get("Members")
 
@@ -234,21 +232,13 @@ def get_event_log_hpe(event_type, redfish_path):
         repaired = grab(event_entry, f"Oem.{plugin_object.rf.vendor_dict_key}.Repaired") or False
 
         status = "OK"
+        if severity == 'WARNING' and repaired is False:
+            if (not date_critical) or (date_critical and entry_date > date_critical.astimezone(entry_date.tzinfo)):
+                status = 'CRITICAL'
+        elif severity != 'OK' and repaired is False:
+            if (not date_warning) or (date_warning and entry_date > date_warning.astimezone(entry_date.tzinfo)):
+                status = 'WARNING'
 
-        if event_type == "System":
-            if severity == "WARNING" and repaired is False:
-                status = "WARNING"
-            elif severity != "OK" and repaired is False:
-                status = "CRITICAL"
-        else:
-
-            if plugin_object.cli_args.critical and date_critical is not None:
-                if entry_date > date_critical.astimezone(entry_date.tzinfo) and severity != "OK":
-                    status = "CRITICAL"
-            if plugin_object.cli_args.warning and date_warning is not None:
-                if entry_date > date_warning.astimezone(entry_date.tzinfo) \
-                        and status != "CRITICAL" and severity != "OK":
-                    status = "WARNING"
 
         plugin_object.add_output_data(status, "%s: %s" % (date, message), is_log_entry=True, log_entry_date=entry_date)
 


### PR DESCRIPTION
When the critical and warning levels are set for event log entries they get converted into date limits.
But these limits had no effect when used on HP servers.