### PR TITLE
Add --sessionlock in Icinga2 command

### DIFF
--- a/contrib/icinga2_check_redfish_command.conf
+++ b/contrib/icinga2_check_redfish_command.conf
@@ -31,6 +31,10 @@ object CheckCommand "redfish" {
             value = "$redfish_sessionfiledir$"
             description = "Directory where the session files should be stored"
         }
+        "--sessionlock" = {
+            set_if = "$redfish_sessionlock$"
+            description = "Create a session lock file to prevent parallel connection sessions"
+        }
         "--warning" = {
             value = "$redfish_warning$"
             description = "Warning threshold for certain checks. See documentation"


### PR DESCRIPTION
Adds the newly added (in 1.8.0) `--sessionlock` parameter in Icinga2 command definition.