### PR TITLE
Fix --sessionlock option to properly check directory before file creation

### DIFF
--- a/cr_module/classes/redfish.py
+++ b/cr_module/classes/redfish.py
@@ -263,7 +263,7 @@ class RedfishConnection:
     def write_session_lock(self):
         if self.cli_args.sessionlock is True and \
                 self.session_file_path is not None and \
-                os.path.exists(self.session_file_lock):
+                os.path.exists(self.session_file_path):
 
             try:
                 with open(self.session_file_lock, 'w') as handle:


### PR DESCRIPTION
Resolved an issue with the --sessionlock option where the lock file was never written. The code was incorrectly checking for the existence of the file rather than the directory. Updated the logic to ensure the directory is checked before attempting to create the session lock file, allowing the file to be written as intended.

With this change I could successfully test that it prevents multiple sessions.

Regards Marcel