### PR TITLE
fix(mem.py): check summary status to be ok before returning OK state

### DIFF
--- a/contrib/icinga2_check_redfish_command.conf
+++ b/contrib/icinga2_check_redfish_command.conf
@@ -31,6 +31,10 @@ object CheckCommand "redfish" {
             value = "$redfish_sessionfiledir$"
             description = "Directory where the session files should be stored"
         }
+        "--sessionlock" = {
+            set_if = "$redfish_sessionlock$"
+            description = "Create a session lock file to prevent parallel connection sessions"
+        }
         "--warning" = {
             value = "$redfish_warning$"
             description = "Warning threshold for certain checks. See documentation"

--- a/cr_module/mem.py
+++ b/cr_module/mem.py
@@ -178,9 +178,16 @@ def get_single_system_mem(redfish_url):
         issue_text = f"Returned data from API URL '{redfish_url}' contains no memory information"
         plugin_object.inventory.add_issue(Memory, issue_text)
     else:
-        plugin_object.add_output_data("OK", f"All {num_dimms} memory modules (Total %.1fGB) are in good condition" % (
-                    size_sum / 1024), summary=True, location=f"System {system_id}")
-
+        if health == "OK":
+            plugin_object.add_output_data("OK", f"All {num_dimms} memory modules (Total %.1fGB) are in good condition" % (
+                        size_sum / 1024), summary=True, location=f"System {system_id}")
+        else:
+            if health.upper() == "WARNING":
+                plugin_status = "WARNING"
+            else:
+                plugin_status = "CRITICAL"
+            plugin_object.add_output_data(plugin_status, f"Memory Summary is {health} but all {num_dimms} memory modules (Total %.1fGB) are in good condition" % (
+                        size_sum / 1024), summary=True, location=f"System {system_id}")
     return
 
 # EOF


### PR DESCRIPTION
At leas on HPE it is possible, that the Memory Summary Health is not OK while all DIMM Modules are reproting GoodInUse.
This adresses the problem by checking the overall memory health before returning OK.

Tested on HPE ProLiant ML30 Gen10

Example of a state with Memory Degarded in Summary but all DIMMs reported as OK:
![grafik](https://github.com/user-attachments/assets/1e2484f4-0845-4f72-bece-b58bf60355f0)
![grafik](https://github.com/user-attachments/assets/b10cbef0-552a-4da8-8be4-cefcc240ea6d)
