### PR TITLE
Add virtual environment check

### DIFF
--- a/check_redfish.py
+++ b/check_redfish.py
@@ -22,6 +22,15 @@ __author__ = "Ricardo Bartels <ricardo@bitchbrothers.com>"
 __description__ = "Check Redfish Plugin"
 __license__ = "MIT"
 
+# check for a virtual environment
+import os
+ACTIVATE_THIS = False
+venv_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '.venv')
+if os.path.exists(venv_path):
+    ACTIVATE_THIS = os.path.join(venv_path, 'bin/activate_this.py')
+if ACTIVATE_THIS and os.path.isfile(ACTIVATE_THIS):
+    exec(open(ACTIVATE_THIS).read(), {'__file__': ACTIVATE_THIS})
+# end virtual environment check
 
 import logging
 


### PR DESCRIPTION
Due to [PEP-668](https://peps.python.org/pep-0668/) on newer python3 versions and systems it seems necessary to work in/with virtual environments. I copied the idea after searching for a solution from [Linuxfabrik Monitoring Plugins](https://github.com/Linuxfabrik/monitoring-plugins) but went for the (in my opinion) default `.venv` name.

This is compatible with virtualenv due to using its `activate_this.py`. Since a virtualenv and dependencies can be easily deployed with i.e. ansible this is a good solution with no need to compile it before enrolment on the target system.