### PR TITLE
Add setup.py variant, extend readme with example installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__
 .idea
 .DS_Store
 venv
+*.egg-info/
+build/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ cd check_redfish
 pip3 install -r requirements.txt || pip install -r requirements.txt
 ```
 
+### Install on any OS with python3.6+ pip
+Install with pip from git
+```
+pip install git+https://github.com/bb-Ricardo/check_redfish
+
+```
+
+Install with pip from git into virtual environment
+```
+python3 -m venv /opt/check_redfish
+/opt/check_redfish/bin/pip install git+https://github.com/bb-Ricardo/check_redfish
+mkdir -p /usr/lib64/nagios/plugins/check_redfish/
+ln -s /opt/check_redfish/bin/check_redfish /usr/lib64/nagios/plugins/check_redfish/check_redfish.py
+```
+
 ### Icinga2 and Grafana
 Command definitions and a service config example for Icinga2 can be found in [contrib](contrib).
 There is also an InfluxDB dashboard for some metrics included.

--- a/check_redfish.py
+++ b/check_redfish.py
@@ -22,7 +22,6 @@ __author__ = "Ricardo Bartels <ricardo@bitchbrothers.com>"
 __description__ = "Check Redfish Plugin"
 __license__ = "MIT"
 
-
 import logging
 
 from cr_module.classes.plugin import PluginData
@@ -36,37 +35,49 @@ from cr_module.args import parse_command_line
 
 from cr_module.classes.inventory import Fan, PowerSupply, Temperature, Memory, Processor
 
+class Check_redfish:
+    def __init__(self):
+        # start here
+        self.args = self.get_cli_args()
+
+    def main(self):
+        if self.args.verbose:
+            # initialize logger
+            logging.basicConfig(level="DEBUG", format='%(asctime)s - %(levelname)s: %(message)s')
+
+        # initialize plugin object
+        plugin = PluginData(self.args, plugin_version=__version__)
+
+        # try to get systems, managers and chassis IDs
+        plugin.rf.discover_system_properties()
+
+        # get basic information
+        plugin.rf.determine_vendor()
+
+        if any(x in self.args.requested_query for x in ['power', 'all']):    get_chassi_data(PowerSupply)
+        if any(x in self.args.requested_query for x in ['temp', 'all']):     get_chassi_data(Temperature)
+        if any(x in self.args.requested_query for x in ['fan', 'all']):      get_chassi_data(Fan)
+        if any(x in self.args.requested_query for x in ['proc', 'all']):     get_system_data(Processor)
+        if any(x in self.args.requested_query for x in ['memory', 'all']):   get_system_data(Memory)
+        if any(x in self.args.requested_query for x in ['nic', 'all']):      get_network_interfaces()
+        if any(x in self.args.requested_query for x in ['storage', 'all']):  get_storage()
+        if any(x in self.args.requested_query for x in ['bmc', 'all']):      get_bmc_info()
+        if any(x in self.args.requested_query for x in ['info', 'all']):     get_system_info()
+        if any(x in self.args.requested_query for x in ['firmware', 'all']): get_firmware_info()
+        if any(x in self.args.requested_query for x in ['mel', 'all']):      get_event_log("Manager")
+        if any(x in self.args.requested_query for x in ['sel', 'all']):      get_event_log("System")
+
+        plugin.do_exit()
+
+    def get_cli_args(self):
+        args = parse_command_line(description, __version__, __version_date__)
+        return args
+
+def main():
+    check_redfish = Check_redfish()
+    check_redfish.main()
 
 if __name__ == "__main__":
-    # start here
-    args = parse_command_line(description, __version__, __version_date__)
-
-    if args.verbose:
-        # initialize logger
-        logging.basicConfig(level="DEBUG", format='%(asctime)s - %(levelname)s: %(message)s')
-
-    # initialize plugin object
-    plugin = PluginData(args, plugin_version=__version__)
-
-    # try to get systems, managers and chassis IDs
-    plugin.rf.discover_system_properties()
-
-    # get basic information
-    plugin.rf.determine_vendor()
-
-    if any(x in args.requested_query for x in ['power', 'all']):    get_chassi_data(PowerSupply)
-    if any(x in args.requested_query for x in ['temp', 'all']):     get_chassi_data(Temperature)
-    if any(x in args.requested_query for x in ['fan', 'all']):      get_chassi_data(Fan)
-    if any(x in args.requested_query for x in ['proc', 'all']):     get_system_data(Processor)
-    if any(x in args.requested_query for x in ['memory', 'all']):   get_system_data(Memory)
-    if any(x in args.requested_query for x in ['nic', 'all']):      get_network_interfaces()
-    if any(x in args.requested_query for x in ['storage', 'all']):  get_storage()
-    if any(x in args.requested_query for x in ['bmc', 'all']):      get_bmc_info()
-    if any(x in args.requested_query for x in ['info', 'all']):     get_system_info()
-    if any(x in args.requested_query for x in ['firmware', 'all']): get_firmware_info()
-    if any(x in args.requested_query for x in ['mel', 'all']):      get_event_log("Manager")
-    if any(x in args.requested_query for x in ['sel', 'all']):      get_event_log("System")
-
-    plugin.do_exit()
+    main()
 
 # EOF

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='check_redfish',
+    version='1.11.0',
+    author='bb-Ricardo',
+    author_email='ricardo.bartels@telekom.de',
+    description='A monitoring/inventory plugin to check components and health status of systems which support Redfish.',
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
+    url='https://github.com/bb-Ricardo/check_redfish',
+    packages=find_packages(),
+    install_requires=[
+        'redfish>=2.1.4',
+    ],
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        "Environment :: Console",
+        'Programming Language :: Python :: 3',
+        "Topic :: System :: Monitoring",
+    ],
+    python_requires='>=3.6',
+    py_modules=["check_redfish"],
+    entry_points={
+        'console_scripts': [
+            'check_redfish=check_redfish:main',
+        ],
+    },
+)


### PR DESCRIPTION
Here is another variant in contrast to https://github.com/bb-Ricardo/check_redfish/pull/158.

This allows installation with i.e. `pip install +git` i.e into a virtual environment. I tested it today and everything seems to work as expected.