### PR TITLE
Adds PowerControl class and integrates power control data

### DIFF
--- a/cr_module/classes/inventory.py
+++ b/cr_module/classes/inventory.py
@@ -313,6 +313,7 @@ class PowerSupply(InventoryItem):
     valid_attributes = {
         "bay": str,
         "capacity_in_watt": int,
+        "efficiency_percent": int,
         "chassi_ids": list,
         "firmware": str,
         "health_status": str,

--- a/cr_module/classes/inventory.py
+++ b/cr_module/classes/inventory.py
@@ -329,6 +329,22 @@ class PowerSupply(InventoryItem):
     }
 
 
+class PowerControl(InventoryItem):
+    inventory_item_name = "power_control"
+    valid_attributes = {
+        "id": str,
+        "name": str,
+        "status": str,
+        "state": str,
+        "reading": int,
+        "power_capacity_watts": int,
+        "power_allocated_watts": int,
+        "power_available_watts": int,
+        "power_consumed_watts": int,
+        "power_requested_watts": int
+    }
+
+
 class Temperature(InventoryItem):
     inventory_item_name = "temperature"
     valid_attributes = {

--- a/cr_module/classes/redfish.py
+++ b/cr_module/classes/redfish.py
@@ -586,10 +586,8 @@ class RedfishConnection:
             if len(chassis) > 0:
                 # try to get vendor from first chassis
                 chassis_data = self.get(chassis[0])
-                if chassis_data is not None:
-                    vendor_string = chassis_data.get("Manufacturer", None)
-                    if vendor_string:
-                        self.vendor_dict_key = vendor_string
+                vendor_string = grab(chassis_data, "Manufacturer")
+                self.vendor_dict_key = vendor_string
 
         if vendor_string in ["Hpe", "Hp"]:
 

--- a/cr_module/classes/redfish.py
+++ b/cr_module/classes/redfish.py
@@ -228,7 +228,7 @@ class RedfishConnection:
         self.session_was_restored = True
 
         return
-    
+
     def remove_session_lock(self):
         if self.cli_args.sessionlock is True and \
                 self.session_file_path is not None and \
@@ -270,7 +270,7 @@ class RedfishConnection:
                     handle.write(str(time.time()))
             except Exception as e:
                 self.exit_on_error(f"Unable to write session lock '{self.session_file_lock}': {e}")
-        
+
     def save_session_to_file(self):
 
         if self.session_file_path is None:
@@ -580,6 +580,16 @@ class RedfishConnection:
             vendor_string = self.connection.root.get("Vendor")
 
             self.vendor_dict_key = vendor_string
+
+        if vendor_string == "" and self.connection.root.get("Chassis") is not None:
+            chassis = self.get_system_properties("chassis")
+            if len(chassis) > 0:
+                # try to get vendor from first chassis
+                chassis_data = self.get(chassis[0])
+                if chassis_data is not None:
+                    vendor_string = chassis_data.get("Manufacturer", None)
+                    if vendor_string:
+                        self.vendor_dict_key = vendor_string
 
         if vendor_string in ["Hpe", "Hp"]:
 

--- a/cr_module/classes/vendor.py
+++ b/cr_module/classes/vendor.py
@@ -189,4 +189,14 @@ class VendorSupermicro(VendorGeneric):
     manager_event_log_entries_path = ["{system_manager_id}/LogServices/Log1"]
     system_event_log_entries_path = ["{system_manager_id}/LogServices/Log1"]
 
+    power_supply_specs = {
+        "PWS-2K22A-1R": {"capacity_in_watt": 2200, "efficiency_percent": 96},
+        "PWS-1K21P-1R": {"capacity_in_watt": 1200, "efficiency_percent": 92},
+        "PWS-2K02P-1R": {"capacity_in_watt": 2000, "efficiency_percent": 91},
+        "PWS-2K02F-1R": {"capacity_in_watt": 2000, "efficiency_percent": 94},
+        "PWS-1K03B-1R": {"capacity_in_watt": 1000, "efficiency_percent": None},
+        "PWS-407P-1R":  {"capacity_in_watt":  400, "efficiency_percent": None},
+        # Add more as needed...
+    }
+
 # EOF

--- a/cr_module/power.py
+++ b/cr_module/power.py
@@ -15,17 +15,6 @@ from cr_module.common import get_status_data, grab
 from cr_module import get_system_power_state
 
 
-_supermicro_power_supply_specs = {
-    "PWS-2K22A-1R": {"capacity_in_watt": 2200, "efficiency_percent": 96},
-    "PWS-1K21P-1R": {"capacity_in_watt": 1200, "efficiency_percent": 92},
-    "PWS-2K02P-1R": {"capacity_in_watt": 2000, "efficiency_percent": 91},
-    "PWS-2K02F-1R": {"capacity_in_watt": 2000, "efficiency_percent": 94},
-    "PWS-1K03B-1R": {"capacity_in_watt": 1000, "efficiency_percent": None},
-    "PWS-407P-1R":  {"capacity_in_watt":  400, "efficiency_percent": None},
-    # Add more as needed...
-}
-
-
 def get_single_chassi_power(redfish_url, chassi_id, power_data):
 
     plugin_object = PluginData()
@@ -62,7 +51,7 @@ def get_single_chassi_power(redfish_url, chassi_id, power_data):
             model = ps.get("Model") or part_number
             last_power_output = ps.get("LastPowerOutputWatts") or ps.get("PowerOutputWatts")
             capacity_in_watt = ps.get("PowerCapacityWatts")
-            efficiency_percent = ps.get("EfficiencyPercent", None)
+            efficiency_percent = ps.get("EfficiencyPercent")
             bay = None
 
             oem_data = grab(ps, f"Oem.{plugin_object.rf.vendor_dict_key}")
@@ -99,7 +88,7 @@ def get_single_chassi_power(redfish_url, chassi_id, power_data):
 
             # special Supermicro case
             if plugin_object.rf.vendor == "Supermicro":
-                info = _supermicro_power_supply_specs.get(model, None)
+                info = plugin_object.rf.vendor_data.power_supply_specs.get(model)
                 if info:
                     capacity_in_watt = info["capacity_in_watt"]
                     efficiency_percent = info["efficiency_percent"]

--- a/cr_module/power.py
+++ b/cr_module/power.py
@@ -15,6 +15,17 @@ from cr_module.common import get_status_data, grab
 from cr_module import get_system_power_state
 
 
+_supermicro_power_supply_specs = {
+    "PWS-2K22A-1R": {"capacity_in_watt": 2200, "efficiency_percent": 96},
+    "PWS-1K21P-1R": {"capacity_in_watt": 1200, "efficiency_percent": 92},
+    "PWS-2K02P-1R": {"capacity_in_watt": 2000, "efficiency_percent": 91},
+    "PWS-2K02F-1R": {"capacity_in_watt": 2000, "efficiency_percent": 94},
+    "PWS-1K03B-1R": {"capacity_in_watt": 1000, "efficiency_percent": None},
+    "PWS-407P-1R":  {"capacity_in_watt":  400, "efficiency_percent": None},
+    # Add more as needed...
+}
+
+
 def get_single_chassi_power(redfish_url, chassi_id, power_data):
 
     plugin_object = PluginData()
@@ -85,6 +96,13 @@ def get_single_chassi_power(redfish_url, chassi_id, power_data):
                     if fujitsu_power_sensor.get("Designation") is not None and \
                             fujitsu_power_sensor.get("Designation").startswith(ps.get("Name")):
                         last_power_output = fujitsu_power_sensor.get("CurrentPowerConsumptionW")
+
+            # special Supermicro case
+            if plugin_object.rf.vendor == "Supermicro":
+                info = _supermicro_power_supply_specs.get(model, None)
+                if info:
+                    capacity_in_watt = info["capacity_in_watt"]
+                    efficiency_percent = info["efficiency_percent"]
 
             ps_id = grab(ps, "MemberId") or ps_num
             # prefix with chassi id if system has more then one

--- a/cr_module/power.py
+++ b/cr_module/power.py
@@ -8,6 +8,7 @@
 #  repository or visit: <https://opensource.org/licenses/MIT>.
 
 import json
+
 from cr_module.classes.inventory import PowerSupply, PowerControl
 from cr_module.classes.plugin import PluginData
 from cr_module.common import get_status_data, grab
@@ -50,6 +51,7 @@ def get_single_chassi_power(redfish_url, chassi_id, power_data):
             model = ps.get("Model") or part_number
             last_power_output = ps.get("LastPowerOutputWatts") or ps.get("PowerOutputWatts")
             capacity_in_watt = ps.get("PowerCapacityWatts")
+            efficiency_percent = ps.get("EfficiencyPercent", None)
             bay = None
 
             oem_data = grab(ps, f"Oem.{plugin_object.rf.vendor_dict_key}")
@@ -100,6 +102,7 @@ def get_single_chassi_power(redfish_url, chassi_id, power_data):
                 serial=ps.get("SerialNumber"),
                 type=ps.get("PowerSupplyType"),
                 capacity_in_watt=capacity_in_watt,
+                efficiency_percent=efficiency_percent,
                 firmware=ps.get("FirmwareVersion"),
                 vendor=ps.get("Manufacturer"),
                 input_voltage=ps.get("LineInputVoltage"),


### PR DESCRIPTION
Referring to issue #171, I provide a patch for this. 

- New class `PowerControl`
- Filling the fields in the `get_single_chassi_power` function, similarly to `PowerSupply`.

I got a bit confused about how to deal with `dict` subelements which get rendered as strings (but they are not valid JSON because of quoting issues).

In particular, I am referring to the following elements in `PowerControl`.

```json
   "PowerLimit": {
      "CorrectionInMs": 0,
      "LimitException": "HardPowerOff",
      "LimitInWatts": 32767
    },
    "PowerMetrics": {
      "AverageConsumedWatts": 102,
      "IntervalInMin": 1,
      "MaxConsumedWatts": 113,
      "MinConsumedWatts": 93
    }
```