### PR TITLE
fix(mem.py): corrected status_text for faulty dimms and memory summary

### DIFF
--- a/cr_module/classes/inventory.py
+++ b/cr_module/classes/inventory.py
@@ -17,7 +17,7 @@ from socket import gethostname
 
 
 # inventory definition
-inventory_layout_version_string = "1.10.0"
+inventory_layout_version_string = "1.12.0"
 
 
 # noinspection PyBroadException

--- a/cr_module/mem.py
+++ b/cr_module/mem.py
@@ -72,6 +72,7 @@ def get_single_system_mem(redfish_url):
 
     num_dimms = 0
     size_sum = 0
+    num_error_dimms = 0
 
     if memory_response.get("Members") or memory_response.get(system_response_memory_key):
 
@@ -153,13 +154,13 @@ def get_single_system_mem(redfish_url):
 
                 num_dimms += 1
                 size_sum += module_size
+                status_text = mem_inventory.operation_status
 
                 if mem_inventory.operation_status in ["GoodInUse", "Operable"]:
                     plugin_status = "OK"
-                    status_text = mem_inventory.operation_status
                 else:
                     plugin_status = mem_inventory.health_status
-                    status_text = plugin_status
+                    num_error_dimms += 1
 
                 if system_power_state != "ON":
                     plugin_status = "OK"
@@ -190,9 +191,15 @@ def get_single_system_mem(redfish_url):
             plugin_status = "WARNING"
         else:
             plugin_status = "CRITICAL"
-        plugin_object.add_output_data(plugin_status,
+        if num_dimms - num_error_dimms == 0:
+            plugin_object.add_output_data(plugin_status,
                                       f"Memory Summary health is reported as '{health.upper()}' but "
                                       f"all {num_dimms} memory modules (Total %.1fGB) are in good condition" % (
+                                      size_sum / 1024), summary=True, location=f"System {system_id}")
+        else:
+            plugin_object.add_output_data(plugin_status,
+                                      f"Memory Summary health is reported as '{health.upper()}' and {num_error_dimms} "
+                                      f"memory modules of {num_dimms} are not in good condition (Total %.1fGB)" % (
                                       size_sum / 1024), summary=True, location=f"System {system_id}")
 
     return


### PR DESCRIPTION
Correction for prevoius missleading message introduced by #141

If there are no faulty dimms but the summary health is not OK, the summary is correct. But if there are faulty dimms, the summary still says that all modules were in good condition, which is missleading and incorrect.

Also the operation_status was only used if the DIMMs were OK. We should use it regardless of the health state instead, to ensure the OEM State is displayed correctly instead of simplified plugin_status


Example before:

> [WARNING]: Memory module PROC 1 DIMM 12 (16.0GB) status is: WARNING
> [WARNING]: Memory Summary health is reported as 'WARNING' but all 6 memory modules (Total 96.0GB) are in good condition
> 

Example after:
> [WARNING]: Memory module PROC 1 DIMM 12 (16.0GB) status is: Degraded
> [WARNING]: Memory Summary health is reported as 'WARNING' and 1 memory modules of 6 are not in good condition (Total 96.0GB)
