### PR TITLE
Auto-ignore missing power supplies for blade chassis (HPE Synergy etc.)

### DIFF
--- a/cr_module/classes/inventory.py
+++ b/cr_module/classes/inventory.py
@@ -17,7 +17,7 @@ from socket import gethostname
 
 
 # inventory definition
-inventory_layout_version_string = "1.10.0"
+inventory_layout_version_string = "1.12.0"
 
 
 # noinspection PyBroadException

--- a/cr_module/power.py
+++ b/cr_module/power.py
@@ -35,6 +35,17 @@ def get_single_chassis_power(redfish_url, chassis_id, power_data, _):
     ps_num = 0
     ps_absent = 0
 
+    # Auto-detect blade chassis and enable ignore_missing_ps
+    # Blade servers don't have individual power supplies as they receive 
+    # power from the enclosure's shared infrastructure
+    chassis_url = redfish_url.replace("/Power", "")
+    chassis_data = plugin_object.rf.get(chassis_url)
+    if chassis_data and chassis_data.get("ChassisType") == "Blade":
+        plugin_object.cli_args.ignore_missing_ps = True
+        plugin_object.add_output_data("OK",
+                                     f"Blade chassis detected - power supplies managed by enclosure",
+                                     summary=True, location=f"Chassis {chassis_id}")
+
     if "PowerSupplies" in power_data:
 
         power_supply_data = list()


### PR DESCRIPTION
In some environments, systems are by design not reporting any power supplies on the chassis level, because the power is entirely managed by an external enclosure. This is the case, for example, with HPE blade servers (e.g. Synergy), where the frame/enclosure provides and manages the PSUs and the individual blade chassis never “sees” any power supplies.

Currently, check_redfish treats the absence of any power supplies as an issue and reports UNKNOWN unless --ignore_missing_ps is explicitly set. For blade systems this is misleading, because there is nothing actually wrong – the hardware simply does not expose PSUs at that level.

This PR introduces the following behavior:

Detects chassis with ChassisType == "Blade" via the Redfish chassis resource.

Automatically sets the ignore_missing_ps behavior for such blade chassis.

Keeps power consumption monitoring via PowerControl working as before.

Avoids raising an issue for “missing” PSUs in scenarios where the enclosure is responsible for power delivery.

From an operator’s perspective this makes the default behavior more correct and less noisy for blade systems, without requiring per‑host --ignore_missing_ps configuration.