### PR TITLE
feat: Add HTTP redirect handling for Redfish session authentication

### DIFF
--- a/cr_module/classes/inventory.py
+++ b/cr_module/classes/inventory.py
@@ -17,7 +17,7 @@ from socket import gethostname
 
 
 # inventory definition
-inventory_layout_version_string = "1.10.0"
+inventory_layout_version_string = "1.12.0"
 
 
 # noinspection PyBroadException


### PR DESCRIPTION
Implement support for HTTP 301/307/308 redirects during Redfish session creation. Older SuperMicro BMCs redirect POST requests from /redfish/v1/SessionService/Sessions to /redfish/v1/SessionService/Sessions/ (trailing slash), causing authentication failures.

Changes:
- Add custom login_with_redirect_handling() method using requests library
- Detect and follow redirect responses during session authentication
- Validate redirect URLs for security (same host, HTTPS, redfish paths)
- Maintain backward compatibility with non-redirect servers
- Preserve all existing error handling and session caching functionality

Error handling preserved:
- 'Unable to connect to Host <host>, max retries exhausted.' for timeouts
- 'Username or password invalid.' for authentication failures
- 'Unable to connect to Host <host>: <error>' for other connection errors

Affected hardware: Older SuperMicro BMC implementations

Fixes authentication issues with SuperMicro servers that enforce trailing slashes on session endpoints.