### PR TITLE
fix: prevent Redfish session leaks causing Dell iDRAC session exhaustion (RAC0218)

### DIFF
--- a/cr_module/classes/redfish.py
+++ b/cr_module/classes/redfish.py
@@ -63,6 +63,8 @@ class RedfishConnection:
         self.init_connection()
 
     def exit_on_error(self, message, level="UNKNOWN"):
+        if self.cli_args is not None and getattr(self.cli_args, 'nosession', False) is True:
+            self.terminate_session()
         self.remove_session_lock()
         print(f"[{level}]: {message}")
         exit(plugin_status_types.get(level))
@@ -301,7 +303,7 @@ class RedfishConnection:
         session_file_handle = None
         try:
             session_file_handle = os.open(self.session_file_path,
-                                          os.O_WRONLY | os.O_CREAT,
+                                          os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
                                           self.desired_session_file_mode)
 
         except PermissionError as e:
@@ -431,6 +433,8 @@ class RedfishConnection:
 
         # reset connection
         if reset is True:
+            if self.connection is not None:
+                self.terminate_session()
             self.connection = None
 
         """


### PR DESCRIPTION
## Problem

Dell iDRAC controllers report **"The maximum number of user sessions is reached" (RAC0218)** when monitored with `check_redfish` — even though the check runs only once per hour and iDRAC is configured with 8 max sessions.

The root cause is a combination of three bugs in `cr_module/classes/redfish.py` that silently leak Redfish sessions on the BMC.

---

## Root Cause Analysis

### Bug 1 — Connection reset without logout (`init_connection`)

When a cached/restored session returns an error (HTTP 401, 503, etc.), `init_connection(reset=True)` is called. This discarded the old connection object by simply setting `self.connection = None` **without** sending an HTTP `DELETE` to the BMC first. The old session stayed alive on the iDRAC until its inactivity timer expired.

```python
# Before (session is leaked)
if reset is True:
    self.connection = None
```
```python
# After (session is explicitly terminated)
if reset is True:
    if self.connection is not None:
        self.terminate_session()
    self.connection = None
```

### Bug 2 — Session leak on error exit with `--nosession` (`exit_on_error`)

`exit_on_error()` called `sys.exit()` immediately. When `--nosession` was in use and the script encountered any runtime error (query timeout, parse error, unexpected API response), it exited without deleting the session it had just created.

```python
# Before
def exit_on_error(self, message, level="UNKNOWN"):
    self.remove_session_lock()
    ...
```
```python
# After
def exit_on_error(self, message, level="UNKNOWN"):
    if self.cli_args is not None and getattr(self.cli_args, 'nosession', False) is True:
        self.terminate_session()
    self.remove_session_lock()
    ...
```

### Bug 3 — Session file written without truncation (`save_session_to_file`)

`os.open()` was called with `os.O_WRONLY | os.O_CREAT` but **without `os.O_TRUNC`**. When a previously pickled connection object was larger than the new one being written (e.g. after a reset), stale bytes remained at the end of the file. This could cause `EOFError` or silent data corruption on the next `restore_session_from_file()` call, forcing a fresh login even when the session was still valid.

```python
# Before
session_file_handle = os.open(self.session_file_path, os.O_WRONLY | os.O_CREAT, ...)

# After
session_file_handle = os.open(self.session_file_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, ...)
```

---

## Why It Manifests Exclusively on Dell iDRAC

The specific environment that exposed this:
- **iDRAC Web Server session timeout: 1800 s (30 min)**
- **Icinga2 normal check interval: 3600 s (60 min)**
- **Icinga2 re-check interval (HARD CRITICAL): 600 s (10 min)**

Because the check interval (60 min) is **longer than the iDRAC session timeout (30 min)**, every hourly check run encounters an already-expired session on the BMC. This triggers `init_connection(reset=True)` every single run, each time leaking the previous session. At 8 max sessions, the iDRAC fills up within 8 hours of normal operation. During the re-check storm (every 10 min) the limit is hit even faster.

Lenovo XClarity BMCs are unaffected likely because they auto-purge idle sessions more aggressively or implement a higher (or no) session limit.

---

## Testing

Tested against **Dell PowerEdge R740xd / iDRAC 9 (14G Monolithic)** running firmware 6.x.

Before fix:
```
Sessions observed on iDRAC before check: 1
Sessions observed on iDRAC after check:  2  ← old session leaked
```

After fix:
```
Sessions observed on iDRAC before check: 1
Sessions observed on iDRAC after check:  1  ← no leak
```

Successful check output:
```
[OK]: INFO: Dell Inc. PowerEdge R740xd (CPU: 2, MEM: 128GB) - BIOS: 2.25.0 - Serial: CNFCP001C4016U - ServiceTag: 23Y0ZP3 - Power: On - Name: backup1-tt1 - 44 health sensors are in 'OK' state
```

---

## Immediate Workaround (No Code Change Required)

For users hitting this issue right now: add `--nosession` to the check command.

```
check_redfish.py -H <bmc_ip> -u monitoring -p <pass> --info --ignore_missing_ps -t 20 --nosession
```

This ensures the session is always explicitly `DELETE`d from the iDRAC after each run. For hourly checks the login overhead is negligible.

---

## Files Changed

- `cr_module/classes/redfish.py` — three targeted one-to-three line fixes, no API or behaviour changes for the normal working path